### PR TITLE
define for DIR and URI

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -10,8 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'JADRO_VERSION', '1.0.0' );
-define( 'JADRO_DIR', rtrim( get_template_directory(), '/' ) );
-define( 'JADRO_URI', rtrim( get_template_directory_uri(), '/' ) );
 
 /**
  * Theme setup.


### PR DESCRIPTION
It is not used inside the theme and it is not necessary.

```
define( 'JADRO_DIR', rtrim( get_template_directory(), '/' ) ); 
define( 'JADRO_URI', rtrim( get_template_directory_uri(), '/' ) );
```